### PR TITLE
Fix winapi features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.11"
 libc = "0.2.81"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["minwinbase"] }
+winapi = { version = "0.3.9", features = ["winbase"] }
 
 [dev-dependencies]
 simple_logger = "1.11.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ pub enum Cause {
 }
 
 impl Cause {
-    fn from_io_err(err: io::Error) -> Self {
+    pub(crate) fn from_io_err(err: io::Error) -> Self {
         Self::WaitFailed(err)
     }
 
@@ -60,8 +60,8 @@ impl Cause {
 /// The bearer of bad news.
 #[derive(Debug)]
 pub struct Error {
-    command: String,
-    cause: Cause,
+    pub(crate) command: String,
+    pub(crate) cause: Cause,
 }
 
 impl Display for Error {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -62,6 +62,17 @@ impl Handle {
         self.as_mut().inner.kill()
     }
 
+    pub fn try_wait(&mut self) -> crate::Result<Option<ExitStatus>> {
+        let Inner { command, inner } = self.as_mut();
+        inner
+            .try_wait()
+            .map_err(crate::Cause::from_io_err)
+            .map_err(|cause| crate::Error {
+                command: command.to_string(),
+                cause,
+            })
+    }
+
     pub fn wait(self) -> crate::Result<ExitStatus> {
         let Inner { command, mut inner } = self.take();
         Error::from_status_result(command, inner.wait())


### PR DESCRIPTION
The `winapi` enabled features are incompatible with the `use winapi::um::winbase::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW}` import. This issue does not appear in cargo-mobile because other crates are enabling this feature, but I couldn't find a way to fix it when using on my own crate :( can you check this and publish a patch?